### PR TITLE
Contents edit function

### DIFF
--- a/app/assets/stylesheets/_contents.scss
+++ b/app/assets/stylesheets/_contents.scss
@@ -4,6 +4,10 @@
 a {
   text-decoration: none;
 }
+h3 {
+  text-align: center;
+  border-bottom: double 5px grey;
+}
 
 .header {
   background-color:#57C3E9;
@@ -164,6 +168,11 @@ a {
     padding: 5px;
     width: 100%;
     margin-top: 10px;
+  }
+
+  .to-toppage {
+    margin-top: 25px;
+    text-align: center;
   }
 
   .post {

--- a/app/assets/stylesheets/_contents.scss
+++ b/app/assets/stylesheets/_contents.scss
@@ -1,6 +1,9 @@
 * {
   box-sizing: border-box;
 }
+a {
+  text-decoration: none;
+}
 
 .header {
   background-color:#57C3E9;
@@ -13,7 +16,7 @@
   a:visited { color:#fff; text-decoration:none }
   &__logo {
     font-size: 60px;
-    text-decoration: none;
+    
     }
     &__user {
       display: flex;
@@ -58,6 +61,7 @@
     max-width: 660px;
     *zoom: 1;
     &__new {
+      width: 100%;
       margin: 20px 0;
       padding: 30px;
       box-shadow: 0 0 10px rgba(41, 41, 41, 0.2);
@@ -65,7 +69,49 @@
       box-sizing: border-box;
     }
   }
+
+  .more {
+    z-index: 2;
+    height: 50px;
+    text-align: right;
+    color:  grey;
+    cursor: pointer;
+    position: relative;
+  }
+  .more:hover ul.more_list {
+    display: block;
+  }
+  .more ul.more_list {
+    position: absolute;
+    text-align: left;
+    width: 80px;
+    right: 0;
+    font-size: 12px;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    display: none;
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
+    border-radius: 3px;
+  }
+
+  .more:hover ul.more_list li{
+    border-bottom: 1px solid #ddd;
+  }
+  .more ul.more_list li:last-child {
+    border-bottom: 0;
+  }
+  .more ul.more_list li a {
+    display: block;
+    padding: 5px;
+    color: grey;
+  }
+  .more ul.more_list li a:hover {
+    background-color: #57C3E9;
+    color: #fff;
+    transition: background-color 0.5s;
+  }
   
+
   .nested-fields {
     &__form{
       display: flex;
@@ -130,7 +176,6 @@
     text-align: center;
     border-radius: 3px;
     display: inline-block;
-    text-decoration: none;
   }
 
   .error-alert {

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -17,6 +17,15 @@ class ContentsController < ApplicationController
     end
   end
 
+  def edit
+    @content = Content.find(params[:id])
+  end
+
+  def update 
+    content = Content.find(params[:id])
+    content.update(content_params)
+  end
+  
   private
 
   def content_params

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -23,9 +23,12 @@ class ContentsController < ApplicationController
 
   def update 
     content = Content.find(params[:id])
-    content.update(content_params)
+    if content.update(content_params)
+    else
+      render :edit
+    end
   end
-  
+
   private
 
   def content_params

--- a/app/views/contents/_main.html.haml
+++ b/app/views/contents/_main.html.haml
@@ -2,11 +2,15 @@
   .main__contents.input
     - @contents.each do |content|
       .main__contents__content.input__new
-        .more
-          = icon("fas", "angle-down")
-          %ul.more_list
-            %li
-              = link_to '編集', edit_content_path(content.id), method: :get
+        - if user_signed_in?
+          - if current_user.id == content.user_id
+            .more
+              = icon("fas", "angle-down")
+              %ul.more_list
+                %li
+                  = link_to '編集', edit_content_path(content.id), method: :get
+          - else
+        -else
         .main__contents__content__title
           = content.title
         - content.choices.each do |choice|

--- a/app/views/contents/_main.html.haml
+++ b/app/views/contents/_main.html.haml
@@ -2,6 +2,11 @@
   .main__contents.input
     - @contents.each do |content|
       .main__contents__content.input__new
+        .more
+          = icon("fas", "angle-down")
+          %ul.more_list
+            %li
+              = link_to '編集', edit_content_path(content.id), method: :get
         .main__contents__content__title
           = content.title
         - content.choices.each do |choice|

--- a/app/views/contents/edit.html.haml
+++ b/app/views/contents/edit.html.haml
@@ -1,0 +1,18 @@
+.input
+  .input__new
+    = form_with model: @content, url: content_path(@content.id), local: true do |f|
+      .title
+        お題を編集する
+      = render "shared/error_messages", model: f.object
+      .input__new__title
+        = f.label :title
+        = f.text_field :title, class: 'title-form', placeholder: "例 : スマホ買い換えるなら、色は？"
+      .input__new__choices
+        .input__new__choices__choice
+          みんなに選んでもらう項目をきめてね！(2つ以上入力)
+        = f.label :text
+        = f.fields_for :choices do |c|
+          = render "choices_fields", f: c
+        .links
+          = link_to_add_association "➕", f, :choices, class: 'add', partial: "choices_fields", data: {association_insertion_method: 'before'}
+      = f.submit "編集完了！", class: 'submit'

--- a/app/views/contents/update.html.haml
+++ b/app/views/contents/update.html.haml
@@ -1,0 +1,6 @@
+.input
+  .input__new
+    %h3
+      更新が完了しました。
+    .to-toppage
+      = link_to 'トップページへ戻る', root_path, class: "submit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'contents#index'
-  resources :contents, only:[:index, :new, :create、:edit]
+  resources :contents, only:[:index, :new, :create, :edit]
   resources :choices do
     resources :votes, only: [:create, :destroy]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'contents#index'
-  resources :contents, only:[:index, :new, :create, :edit]
+  resources :contents, only:[:index, :new, :create, :edit, :update]
   resources :choices do
     resources :votes, only: [:create, :destroy]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'contents#index'
-  resources :contents, only:[:index, :new, :create]
+  resources :contents, only:[:index, :new, :create、:edit]
   resources :choices do
     resources :votes, only: [:create, :destroy]
   end


### PR DESCRIPTION
#WHAT
お題編集機能の実装
- 投稿情報（お題・項目）の変更ができる。
- 投稿者だけが編集ページへ遷移できる。
- 投稿時と同じUIで編集ができる。
- 既に登録されている情報は編集画面を開いた時点で表示されている。
- エラーハンドリングの実装（更新に失敗した場合は編集画面へ戻る）。

#WHY
投稿内容ミスの修正や、都合に応じて投稿内容を変更したいというユーザーの希望に応えるため。
